### PR TITLE
Modify build-all.sh to use LZFSE disk image format

### DIFF
--- a/release/build-all.sh
+++ b/release/build-all.sh
@@ -38,7 +38,7 @@ done
 VERSION=`date +'%Y%m%d'`
 DMGPATH="aleph-mac-frameworks-$VERSION.dmg"
 if [ -f "$DMGPATH" ]; then rm "$DMGPATH"; fi
-hdiutil create -ov -fs HFS+ -format UDBZ -layout GPTSPUD -srcfolder "$PKGDIR" -volname "Aleph One Frameworks $VERSION" "$DMGPATH"
+hdiutil create -ov -fs HFS+ -format ULFO -layout GPTSPUD -srcfolder "$PKGDIR" -volname "Aleph One Frameworks $VERSION" "$DMGPATH"
 if [ "$SIGNATURE" == "" ]; then
   echo "No signature provided. Disk image is unsigned."
 else


### PR DESCRIPTION
Modify build-all.sh to use ULFO disk image format based on LZFSE codec. ULFO images were introduced in 2015's macOS 10.11 (El Capitan). The LZFSE codec itself is open source and provides good compression with substantially better performance, especially compared to bzip2 (UDBZ). Additionally, UDBZ images have been deprecated in macOS 12 Monterey. Discussed this in Discord and this script may not be currently in use, but I just wanted to submit this for completeness.